### PR TITLE
Rename authorization to authentication for --auth configuration option

### DIFF
--- a/locale/es/LC_MESSAGES/reference/program/mongod.po
+++ b/locale/es/LC_MESSAGES/reference/program/mongod.po
@@ -1471,7 +1471,7 @@ msgstr ""
 
 #: ../source/includes/option/option-mongod-auth.rst:3
 msgid ""
-"Enables authorization to control user's access to database resources and "
+"Enables authentication to control user's access to database resources and "
 "operations. When authorization is enabled, MongoDB requires all clients to "
 "authenticate themselves first in order to determine the access for the "
 "client."


### PR DESCRIPTION
Rename *authorization* to *authentication* for `--auth` configuration option, to match terminology in `--noauth` option and elsewhere.